### PR TITLE
Miscellaneous cleanup of host code:

### DIFF
--- a/samples/flutter/todo/lib/main.dart
+++ b/samples/flutter/todo/lib/main.dart
@@ -31,7 +31,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  static final _replicant = Replicant('replicant.dev/samples/todo');
+  static final _replicant = Replicant();
 
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
@@ -85,7 +85,6 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       registeredVersion = await _replicant.exec('codeVersion');
     } catch (e) {
-      print(e.toString());
       // https://github.com/aboodman/replicant/issues/25
       if (!e.toString().contains("Unknown function: codeVersion")) {
         throw e;

--- a/samples/flutter/todo/lib/replicant.dart
+++ b/samples/flutter/todo/lib/replicant.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
+const CHANNEL_NAME = 'replicant.dev';
+
 class Replicant {
   MethodChannel _platform;
 
-  Replicant(String channel) {
-     _platform = MethodChannel(channel);
+  Replicant() {
+     _platform = MethodChannel(CHANNEL_NAME);
   }
 
   Future<void> putBundle(String bundle) {


### PR DESCRIPTION
- Change the channel name to something general, since we don't know how to have two Replicant databases in the same Flutter process anyway.
- Make logging more consistent between iOS and Android.
- Make general approach of host code consistent between platforms.
- Make sure to synchronize on connection initialization since this is running on multiple threads now.