### PR TITLE
Formalize versioning of bundles

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -189,8 +189,38 @@ func (db *DB) execImpl(basis types.Ref, bundle types.Blob, function string, args
 			output = types.Bool(ok)
 			break
 		case ".putBundle":
-			newBundle = db.noms.WriteValue(args.Get(uint64(0)).(types.Blob))
-			isWrite = true
+			cb := db.head.Bundle(db.noms)
+			nb := args.Get(uint64(0)).(types.Blob)
+			if cb.Equals(nb) {
+				fmt.Printf("Bundle %s already installed, skipping\n", cb.Hash())
+				break
+			}
+
+			var currentVersion, newVersion float64
+			currentVersion, err = db.getBundleVersion(cb)
+			if err != nil {
+				return
+			}
+			newVersion, err = db.getBundleVersion(nb)
+			if err != nil {
+				return
+			}
+			shouldUpdate := func() bool {
+				if currentVersion == 0 && newVersion == 0 {
+					fmt.Printf("Replacing unversioned bundle %s with %s\n", cb.Hash(), nb.Hash())
+					return true
+				}
+				if newVersion > currentVersion {
+					fmt.Printf("Upgrading bundle from %f to %f\n", currentVersion, newVersion)
+					return true
+				}
+				fmt.Printf("Proposed bundle version %f not better than current version %f, skipping update\n", newVersion, currentVersion)
+				return false
+			}
+			if shouldUpdate() {
+				newBundle = db.noms.WriteValue(nb)
+				isWrite = true
+			}
 			break
 		}
 	} else {
@@ -205,4 +235,23 @@ func (db *DB) execImpl(basis types.Ref, bundle types.Blob, function string, args
 	}
 
 	return newBundle, newData, output, isWrite, nil
+}
+
+func (db *DB) getBundleVersion(bundle types.Blob) (float64, error) {
+	// TODO: Passing editor is not really necessary because the script cannot call
+	// it because it only has access to the `db` object which is passed as a param
+	// to transaction functions. We only need to pass something here because the
+	// impl of exec.Run() requires ed.noms.
+	ed := &editor{noms: db.noms, data: nil}
+	r, err := exec.Run(ed, bundle.Reader(), "codeVersion", types.NewList(db.noms))
+	if _, ok := err.(exec.UnknownFunctionError); ok {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if r == nil || r.Kind() != types.NumberKind {
+		return 0, errors.New("codeVersion() must return a number")
+	}
+	return float64(r.(types.Number)), nil
 }

--- a/exec/otto.go
+++ b/exec/otto.go
@@ -21,6 +21,12 @@ const (
 	cmdDel
 )
 
+type UnknownFunctionError string
+
+func (ufe UnknownFunctionError) Error() string {
+	return fmt.Sprintf("Unknown function: %s", string(ufe))
+}
+
 type Database interface {
 	Noms() types.ValueReadWriter
 	Put(id string, value types.Value) error
@@ -128,7 +134,7 @@ func Run(db Database, source io.Reader, fn string, args types.List) (types.Value
 	ok, err := okv.ToBoolean()
 	chk.NoError(err)
 	if !ok {
-		return nil, fmt.Errorf("Unknown function: %s", fn)
+		return nil, UnknownFunctionError(fn)
 	}
 
 	res, err := obj.Get("result")

--- a/samples/flutter/todo/assets/bundle.js
+++ b/samples/flutter/todo/assets/bundle.js
@@ -1,5 +1,5 @@
 function codeVersion() {
-    return 2;
+    return 3;
 }
 
 function init() {

--- a/samples/flutter/todo/lib/main.dart
+++ b/samples/flutter/todo/lib/main.dart
@@ -8,8 +8,6 @@ import 'model.dart';
 import 'replicant.dart';
 import 'settings.dart';
 
-const bundleVersion = 2;
-
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
@@ -68,7 +66,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _init() async {
-    await _registerBundle();
+    await _replicant.putBundle(await rootBundle.loadString('assets/bundle.js', cache: false));
     await _replicant.exec('init');
     await _load();
     _sync(force: true);
@@ -85,23 +83,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _handleDoneChanged(String id, bool isDone) async {
     await _replicant.exec('setDone', [id, isDone]);
-  }
-
-  Future<void> _registerBundle() async {
-    var registeredVersion = 0;
-    try {
-      registeredVersion = await _replicant.exec('codeVersion');
-    } catch (e) {
-      // https://github.com/aboodman/replicant/issues/25
-      if (!e.toString().contains("Unknown function: codeVersion")) {
-        throw e;
-      }
-    }
-
-    if (registeredVersion < bundleVersion) {
-      await _replicant.putBundle(await rootBundle.loadString('assets/bundle.js', cache: false));
-      print("Upgraded bundle version from $registeredVersion to $bundleVersion");
-    }
   }
 
   Future<void> _sync({force:false}) async {


### PR DESCRIPTION
Bundles can now optionally include a codeVersion() field that returns a float. Someday we can expand this to semver if desired, but that will be compatible with returning a float.

If putBundle() is called with a bundle whose version is <= the currently registered bundle, the call is ignored.

As a special case for development, a bundle that includes no codeVersion() (called "unversioned") is allowed to upgrade another unversioned bundle.

Fixes #26