### PR TITLE
Serialize access to a single database on the server.

### DIFF
--- a/serve/serve.go
+++ b/serve/serve.go
@@ -118,9 +118,13 @@ func getServer(name string) (*server, error) {
 type server struct {
 	router *httprouter.Router
 	db     *db.DB
+	mu     sync.Mutex
 }
 
 func (s *server) sync(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	err := s.db.Reload()
 	if err != nil {
 		serverError(w, err)


### PR DESCRIPTION
We can still have cross-process parallelism and at a fundamental level this is fine for Noms and Replicant. It's just the Database struct that has to be thought through more carefully from a concurrency perspective.