### PR TITLE
Fixed shallow sync bug not returning data.

### DIFF
--- a/db/shallow_sync.go
+++ b/db/shallow_sync.go
@@ -48,5 +48,5 @@ func (db *DB) HackyShallowSync(remote spec.Spec, progress func(p Progress)) erro
 	}
 
 	db.noms.SetHead(db.noms.GetDataset(LOCAL_DATASET), db.noms.WriteValue(marshal.MustMarshal(db.noms, c)))
-	return nil
+	return db.init()
 }

--- a/db/shallow_sync_test.go
+++ b/db/shallow_sync_test.go
@@ -30,6 +30,8 @@ func TestShallowSync(t *testing.T) {
 	rspec, err := spec.ForDatabase(rdir)
 	assert.NoError(err)
 	err = local.HackyShallowSync(rspec, progress)
+	assert.Equal(remote.head.Original.Get("value").Hash(), local.head.Original.Get("value").Hash())
+	assert.NotEqual(remote.head.Original.Hash(), local.head.Original.Hash())
 	assert.NoError(err)
 	assert.True(count > 0)
 }


### PR DESCRIPTION
Shallow sync wasn't returning the root node causing the onChange event not to invoke.

Fixes #140 